### PR TITLE
fix inconsequential mixin error

### DIFF
--- a/src/main/resources/mixins.serverlistbufferfixer.json
+++ b/src/main/resources/mixins.serverlistbufferfixer.json
@@ -1,5 +1,6 @@
 {
   "compatibilityLevel": "JAVA_8",
+  "minVersion": "0.7",
   "package": "me.nixuge.serverlistbufferfixer.mixins",
   "refmap": "refmap.serverlistbufferfixer.json",
   "mixins": [],


### PR DESCRIPTION
fixes 'Mixin config mixins.serverlistbufferfixer.json does not specify "minVersion" property'